### PR TITLE
Quiet deprecation warning re: legacy RSpec matcher protocol

### DIFF
--- a/lib/bean_counter/enqueued_expectation.rb
+++ b/lib/bean_counter/enqueued_expectation.rb
@@ -154,7 +154,7 @@ class BeanCounter::EnqueuedExpectation
        found_string,
     ].join(' ')
   end
-
+  alias failure_message_when_negated negative_failure_message
 
   # Evaluates jobs enqueued during the execution of the provided block to
   # determine if any jobs were enqueued that match the expected options provided


### PR DESCRIPTION
Warning was: "BeanCounter::EnqueuedExpectation implements a legacy RSpec matcher protocol. For the current protocol you should expose the failure messages via the `failure_message` and `failure_message_when_negated` methods."
